### PR TITLE
Update config.js. Redis's "port" key was "post"

### DIFF
--- a/config.js
+++ b/config.js
@@ -16,7 +16,7 @@ module.exports = {
 	publicsalt: 'i m another random string, change me.',
 
 	redis: {
-		post: 6379,
+		port: 6379,
 		host: '127.0.0.1',
 		// password: '...my redis password...',
 		// database: ...0~15...


### PR DESCRIPTION
The redis section of config file had an wrong key "post" insted of "port". Fixed.
