### PR TITLE
npm stop was not making forever stop oauthd.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "scripts": {
     "install": "grunt",
-    "start": "forever --minUptime 1000 --spinSleepTime 1000 -a -l forever.log -o out.log -e err.log start ./lib/oauthd.js",
-    "stop": "forever stop ./lib/oauthd.js",
+    "start": "forever --minUptime 1000 --spinSleepTime 1000 -a -l forever.log -o out.log -e err.log start lib/oauthd.js",
+    "stop": "forever stop lib/oauthd.js",
     "test": "grunt test && coffee ./test/providers_check.coffee"
   },
   "keywords": [


### PR DESCRIPTION
I updated all the packages to the latest version and forever was not recognizing ./lib/oauthd.js it works with lib/oauthd.js
