### PR TITLE
Added support for accept header

### DIFF
--- a/lib/oauth1.coffee
+++ b/lib/oauth1.coffee
@@ -82,6 +82,19 @@ exports.authorize = (provider, parameters, opts, callback) ->
 				consumer_key: parameters.client_id
 				consumer_secret: parameters.client_secret
 		delete query.oauth_callback
+
+		switch request_token.format
+			when 'json'
+				acceptHeader = 'application/json'
+			when 'url'
+				acceptHeader = 'application/x-www-form-urlencoded'
+			else
+				acceptHeader = null
+		if acceptHeader
+			if not options.headers
+				options.headers = []
+			options.headers["Accept"] = acceptHeader
+
 		if options.method == 'POST'
 			options.form = query
 		else


### PR DESCRIPTION
When explicitly setting the request_token format, the request's Accept header is set to to the expected format.
