### PR TITLE
Fix tests for format specifier in providers’ configurations

### DIFF
--- a/test/provider_schema.coffee
+++ b/test/provider_schema.coffee
@@ -176,7 +176,7 @@ module.exports =
 								"format":
 									description: "force the response content type"
 									type: "string"
-									enum: ["json", "url", "application/json", "application/x-www-form-urlencoded"]
+									enum: ["json", "url"]
 								"query":
 									type: "object"
 						}
@@ -198,7 +198,7 @@ module.exports =
 								"format":
 									description: "force the response content type"
 									type: "string"
-									enum: ["json", "url", "application/json", "application/x-www-form-urlencoded"]
+									enum: ["json", "url"]
 								"query":
 									type: "object"
 						}


### PR DESCRIPTION
As `oauth1.coffee` uses `request_token.format` and `access_token.format` (see [oauth1.coffee](https://github.com/oauth-io/oauthd/blob/3cdabf1dbda7a7ea406625160f7fd1e2405bab01/lib/oauth1.coffee) – L102, L104, L209, L211) the tests shouldn’t throw a warning if they are used. Furthermore, the tests allowed `application/json` and `application/x-www-form-urlencoded` as a value for `access_token.format` and `refresh.format`, however, the actual `oauth2.coffee` didn’t check for these values, so I removed them.
