### PR TITLE
Fix Set-Cookie expiration dates to be in UTC/GMT format per RFC 6265

### DIFF
--- a/plugins/server.admin.auth/server_admin_auth.coffee
+++ b/plugins/server.admin.auth/server_admin_auth.coffee
@@ -114,7 +114,8 @@ exports.setup = (callback) ->
 		hooks.grantClientToken req.body.name, req.body.pass, (e, token) =>
 			return next(e) if e
 			if token
-				res.setHeader 'Set-Cookie', 'accessToken=%22' + token + '%22; Path=/; Expires=' + new Date((new Date-0)+_config.expire*1000)
+				expireDate = new Date((new Date - 0) + _config.expire * 1000)
+				res.setHeader 'Set-Cookie', 'accessToken=%22' + token + '%22; Path=/; Expires=' + expireDate.toUTCString()
 			res.setHeader 'Location', @config.host_url + @config.base
 			res.send 302
 			next()


### PR DESCRIPTION
This bug prevented the accessToken cookie from being set on Chrome.

Fixes issue #32.
