### PR TITLE
Server Side signed requests are failing with any version of request npm package newer than 2.25.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "redis": "~0.9.2",
     "restify": "~2.5.1",
     "async": "~0.2.9",
-    "request": "~2.30.0",
+    "request": "~2.25.0",
     "nodemailer": "~0.4.4",
     "underscore": "~1.4.4",
     "restify-oauth2-oauthd": "~2.1.0"


### PR DESCRIPTION
This is an example code to verify the bug:

``` js
function init() {
    "use strict";

    OAuth.initialize('YOUR_KEY');

    var linkedinButton = document.getElementById('load-linkedin');
    linkedinButton.addEventListener('click', function () {
        OAuth.popup('linkedin', function(err, result) {
            showError(err);
            processLinkedinResult(result);
        });
    });
}

function processLinkedinResult(result) {
    "use strict";

    console.log(result);

    result.get('/v1/people/~').done(function(data) { // this will fail
        processLinkedInData(data);
    });

}

function processLinkedInData(data) {
    "use strict";

    var linkedinInfo = document.getElementById('linkedin-info');
    var firstName = data.evaluate('/person/first-name', data, null, XPathResult.ANY_TYPE, null).iterateNext().textContent;
    var lastName = data.evaluate('/person/last-name', data, null, XPathResult.ANY_TYPE, null).iterateNext().textContent;
    linkedinInfo.innerText = firstName + ' ' + lastName;
    linkedinInfo.textContent = firstName + ' ' + lastName;

}

function showError(err) {
    "use strict";
    if (!!err) {
        for (var key in err.body) {
            alert(key);
        }
    }
}
```

I strongly suggest that this should be added as a test case.
