### PR TITLE
 "ref undefined" error while doing non CORS requests

### DIFF
--- a/plugins/server.request/server_request.coffee
+++ b/plugins/server.request/server_request.coffee
@@ -30,6 +30,10 @@ exports.raw = ->
 
 	@apiRequest = (req, provider_name, oauthio, callback) =>
 		req.headers ?= {}
+		ref = fixUrl(req.headers['referer'] || req.headers['origin'] || "http://localhost");
+		urlinfos = Url.parse(ref)
+		if not urlinfos.hostname
+			return next new restify.InvalidHeaderError 'Missing origin or referer.'
 		async.parallel [
 			(callback) => @db.providers.getExtended provider_name, callback
 			(callback) => @db.apps.getKeyset oauthio.k, provider_name, callback


### PR DESCRIPTION
This fixes the "ref undefined" error in the following line
Line 40: (callback) => @db.apps.checkDomain oauthio.k, ref, callback
of  exports.raw function
