### PR TITLE
Refactored request options creation

### DIFF
--- a/lib/oauth-base.coffee
+++ b/lib/oauth-base.coffee
@@ -143,7 +143,7 @@ class OAuthBase
 			headers[name] = param if param
 		return headers
 
-	_buildOptions: (configuration, placeholderValues, headers, query) ->
+	_buildRequestOptions: (configuration, placeholderValues, headers, query) ->
 		method = configuration.method?.toUpperCase() || 'POST'
 		options = {
 			url: @_replaceParam(configuration.url, placeholderValues)

--- a/lib/oauth1.coffee
+++ b/lib/oauth1.coffee
@@ -35,20 +35,13 @@ class OAuth1 extends OAuthBase
 		placeholderValues = { state: state.id, callback: @_serverCallbackUrl }
 		query = @_buildQuery(configuration.query, placeholderValues, opts.options?.request_token)
 		headers = @_buildHeaders(configuration)
-		options =
-			url: configuration.url
-			method: configuration.method?.toUpperCase() || "POST"
-			encoding: null
-			oauth:
-				callback: query.oauth_callback
-				consumer_key: @_parameters.client_id
-				consumer_secret: @_parameters.client_secret
+		options = @_buildRequestOptions(configuration, {}, headers, query)
+		options.oauth = {
+			callback: query.oauth_callback
+			consumer_key: @_parameters.client_id
+			consumer_secret: @_parameters.client_secret
+		}
 		delete query.oauth_callback
-		options.headers = headers if Object.keys(headers).length
-		if options.method == 'POST'
-			options.form = query
-		else
-			options.qs = query
 
 		# do request to request_token
 		request options, (err, response, body) =>
@@ -91,7 +84,8 @@ class OAuth1 extends OAuthBase
 		@_setExtraRequestAuthorizeParameters(req, placeholderValues)
 		query = @_buildQuery(configuration.query, placeholderValues)
 		headers = @_buildHeaders(configuration)
-		options = @_buildOptions(configuration, placeholderValues, headers, query)
+		# This is the only call that replaces placeholders in url
+		options = @_buildRequestOptions(configuration, placeholderValues, headers, query)
 		options.oauth = {
 			callback: query.oauth_callback
 			consumer_key: @_parameters.client_id
@@ -128,7 +122,6 @@ class OAuth1 extends OAuthBase
 			return callback new check.Error "You must provide 'oauth_token' and 'oauth_token_secret' in 'oauthio' http header"
 
 		options = @_buildServerRequestOptions(req)
-
 		options.oauth =
 			consumer_key: @_parameters.client_id
 			consumer_secret: @_parameters.client_secret

--- a/lib/oauth2.coffee
+++ b/lib/oauth2.coffee
@@ -49,7 +49,7 @@ class OAuth2 extends OAuthBase
 		placeholderValues = { code: req.params.code, state: state.id, callback: @_serverCallbackUrl }
 		query = @_buildQuery(configuration.query, placeholderValues)
 		headers = @_buildHeaders(configuration)
-		options = @_buildOptions(configuration, {}, headers, query)
+		options = @_buildRequestOptions(configuration, {}, headers, query)
 		options.followAllRedirects = true
 
 		# do request to access_token
@@ -77,16 +77,8 @@ class OAuth2 extends OAuthBase
 		placeholderValues = { refresh_token: token }
 		query = @_buildQuery(configuration.query, placeholderValues)
 		headers = @_buildHeaders(configuration, { refresh_token: token })
-		options =
-			url: @_replaceParam configuration.url, {}
-			method: configuration.method?.toUpperCase() || "POST"
-			followAllRedirects: true
-
-		options.headers = headers if Object.keys(headers).length
-		if options.method == "GET"
-			options.qs = query
-		else
-			options.form = query # or .json = qs for json post
+		options = @_buildRequestOptions(configuration, {}, headers, query)
+		options.followAllRedirects = true
 
 		# request new token
 		request options, (e, r, body) =>


### PR DESCRIPTION
## Review 1

Please review line 88 of OAuth.coffee where there is the comment:
`# This is the only call that replaces placeholders in url`. 
Why are all the other code paths not replacing placeholders in urls?
## Review 2

In OAuth1 the response options where build with the following code:

``` coffee
if options.method == 'POST'
    options.form = query
else
    options.qs = query
```

In OAuth2 with this:

``` coffee
if options.method == "GET"
    options.qs = query
else
    options.form = query # or .json = qs for json post
```

I implemented this in the new code with the following logic, as per my understanding of RFC, only GET methods can have query strings:

``` coffee
form: query if method != 'GET'
qs: query if method == 'GET'
```
