### PR TITLE
Add Pocket provider

### DIFF
--- a/lib/oauth-base.coffee
+++ b/lib/oauth-base.coffee
@@ -63,6 +63,9 @@ class OAuthBase
 			query[parameterName] = param if param?
 		return query
 
+	_buildResponseParameters: (configuration, placeholderValues, defaultParameters) ->
+		@_buildQuery configuration, placeholderValues, defaultParameters
+
 	_buildAuthorizeUrl: (url, query, stateId) ->
 		url = @_replaceParam(url, {})
 		url += "?" + querystring.stringify(query)

--- a/lib/oauth-base.coffee
+++ b/lib/oauth-base.coffee
@@ -60,7 +60,7 @@ class OAuthBase
 		# with matching placeholderValues's 'placeholder1' value
 		for parameterName, placeholder of configuration
 			param = @_replaceParam(placeholder, placeholderValues)
-			query[parameterName] = param if param
+			query[parameterName] = param if param?
 		return query
 
 	_buildAuthorizeUrl: (url, query, stateId) ->

--- a/lib/oauth1-response-parser.coffee
+++ b/lib/oauth1-response-parser.coffee
@@ -7,18 +7,24 @@ class OAuth1ResponseParser extends OAuthResponseParser
 		super response, body, format, tokenType
 
 	parse: (callback) ->
-		super (e, r) =>
+		@parseGenericResponse (e, r) =>
 			return callback e if e
 
-			if @body.error or @body.error_description
-				return callback @_setError @body.error_description || 'Error in response'
+			@parseOAuth1 callback
 
-			return callback @_setError 'oauth_token not found' if not @body.oauth_token
-			return callback @_setError 'oauth_token_secret not found' if not @body.oauth_token_secret?
+	parseGenericResponse: (callback) ->
+		OAuth1ResponseParser.__super__.parse.call @, callback
 
-			@oauth_token = @body.oauth_token
-			@oauth_token_secret = @body.oauth_token_secret
+	parseOAuth1: (callback) ->
+		if @body.error or @body.error_description
+			return callback @_setError @body.error_description || 'Error in response'
 
-			callback null, @
+		return callback @_setError 'oauth_token not found' if not @body.oauth_token
+		return callback @_setError 'oauth_token_secret not found' if not @body.oauth_token_secret?
+
+		@oauth_token = @body.oauth_token
+		@oauth_token_secret = @body.oauth_token_secret
+
+		callback null, @
 
 module.exports = OAuth1ResponseParser

--- a/lib/oauth1.coffee
+++ b/lib/oauth1.coffee
@@ -61,7 +61,12 @@ class OAuth1 extends OAuthBase
 				db.states.setToken state.id, response.oauth_token_secret, (err, returnCode) =>
 					return callback err if err
 					configuration = @_oauthConfiguration.authorize
-					placeholderValues = { state: state.id, callback: @_serverCallbackUrl }
+					placeholderValues = {
+						state: state.id
+						callback: @_serverCallbackUrl
+						oauth_token: response.oauth_token
+						oauth_token_secret: response.oauth_token_secret
+					}
 					query = @_buildQuery(configuration.query, placeholderValues, opts.options?.authorize)
 					query.oauth_token = response.oauth_token
 					callback null, @_buildAuthorizeUrl(configuration.url, query, state.id)
@@ -86,7 +91,12 @@ class OAuth1 extends OAuthBase
 		return callback err if err.failed()
 
 		configuration = @_oauthConfiguration.access_token
-		placeholderValues = { state: state.id, callback: @_serverCallbackUrl }
+		placeholderValues = {
+			state: state.id
+			callback: @_serverCallbackUrl
+			oauth_token: req.params.oauth_token
+			oauth_token_secret: req.params.oauth_token_secret
+		}
 		@_setExtraRequestAuthorizeParameters(req, placeholderValues)
 		query = @_buildQuery(configuration.query, placeholderValues)
 		headers = @_buildHeaders(configuration)

--- a/providers/pocket/conf.json
+++ b/providers/pocket/conf.json
@@ -1,0 +1,54 @@
+{
+	"name": "Pocket",
+	"url": "https://getpocket.com/v3/oauth",
+	"oauth1": {
+		"request_token": {
+			"url": "/request",
+			"query": {
+				"consumer_key": "{consumer_key}",
+				"redirect_uri": "{{callback}}",
+				"state": "{{state}}"
+			},
+			"response": {
+				"oauth_token": "{{code}}",
+				"oauth_token_secret": ""
+			},
+			"headers": {
+				"Content-Type": "application/x-www-form-urlencoded; charset=UTF8"
+			}
+		},
+		"authorize": {
+			"url": "https://getpocket.com/auth/authorize",
+			"query": {
+				"request_token": "{{oauth_token}}",
+				"redirect_uri": "{{callback}}?state={{state}}&oauth_token={{oauth_token}}"
+			},
+			"ignore_verifier": true
+		},
+		"access_token": {
+			"url": "/authorize",
+			"query": {
+				"consumer_key": "{consumer_key}",
+				"code": "{{oauth_token}}",
+				"oauth_token": "{{oauth_token}}"
+			},
+			"response": {
+				"oauth_token": "{{access_token}}",
+				"oauth_token_secret": ""
+			},
+			"headers": {
+				"Content-Type": "application/x-www-form-urlencoded; charset=UTF8"
+			}
+		},
+		"request": "https://getpocket.com/v3",
+		"parameters": {
+			"consumer_key": "string"
+		}
+	},
+	"href": {
+		"keys": "http://getpocket.com/developer/apps/new",
+		"docs": "http://getpocket.com/developer/docs/overview",
+		"apps": "http://getpocket.com/developer/apps/",
+		"provider": "https://getpocket.com"
+	}
+}


### PR DESCRIPTION
This adds support for [Pocket](https://getpocket.com).

Quite a few changes to the daemon itself were necessary as Pocket uses “a variant of OAuth 2.0”. Basically, it resembles the OAuth 1.0 protocol but uses terminology from OAuth 2.0.

To work around that, I have added a `response` object to the provider’s configuration which works similarly to the `query` object but you can use response parameters as placeholders. For example, the API returns `code` instead of `oauth_token` so the configuration file defines `"oauth_token": "{{code}}"`.

Furthermore, you can now use `oauth_token` and `oauth_token_secret` in query objects.

If you’re fine with that approach I could add a few words to the documentation and adjust the tests.
