### PR TITLE
change flickr api endpoint to use https (suspect request API broken since switch to ssl-only 2014-06-27)

### DIFF
--- a/providers/flickr/conf.json
+++ b/providers/flickr/conf.json
@@ -1,7 +1,7 @@
 {
     "name": "Flickr",
     "desc": "The Flickr API can be used to retrieve photos from the Flickr photo sharing service using a variety of feeds - public photos and videos, favorites, friends, group pools, discussions, and more. The API can also be used to upload photos and video.The Flickr API supports many protocols including REST, SOAP, XML-RPC. Responses can be formatted in XML, XML-RPC, JSON and PHP. Documentation is included for 14 API Kit libraries.",
-    "url": "http://www.flickr.com/services/oauth",
+    "url": "https://www.flickr.com/services/oauth",
     "oauth1": {
         "request_token": "/request_token",
         "authorize": {


### PR DESCRIPTION
Hi!

I am developing a small js app using the flickr api via oauth.io. Requests initially had been working fine in May when I started developing. Recently I looked at the app again and now although the initial token retrieval via popup still works fine all the requests through the oauth.io server fail with http status code:
"403 Forbidden"
and response:
 {"stat":"fail", "code":95, "message":"SSL is required"}

I suspect this is because of the flickr api went ssl-only on june 27th:
http://code.flickr.net/2014/04/30/flickr-api-going-ssl-only-on-june-27th-2014/

I set up a local instance of oauthd and was able to reproduce the problem with the http endpoint and could then confirm that changing the endpoint url to https (this pull request) makes everything work again.

  Fabian
