### PR TITLE
change flickr api endpoint to use https

### DIFF
--- a/providers/flickr/conf.json
+++ b/providers/flickr/conf.json
@@ -1,7 +1,7 @@
 {
     "name": "Flickr",
     "desc": "The Flickr API can be used to retrieve photos from the Flickr photo sharing service using a variety of feeds - public photos and videos, favorites, friends, group pools, discussions, and more. The API can also be used to upload photos and video.The Flickr API supports many protocols including REST, SOAP, XML-RPC. Responses can be formatted in XML, XML-RPC, JSON and PHP. Documentation is included for 14 API Kit libraries.",
-    "url": "http://www.flickr.com/services/oauth",
+    "url": "https://www.flickr.com/services/oauth",
     "oauth1": {
         "request_token": "/request_token",
         "authorize": {


### PR DESCRIPTION
the flickr api went ssl-only on june 27th, read more:
http://code.flickr.net/2014/04/30/flickr-api-going-ssl-only-on-june-27th-2014/

I updated my patch to be against the latest develop branch in case that was the reason why https://github.com/oauth-io/oauthd/pull/101 was closed. https://github.com/oauth-io/oauthd/issues/121 is about the same issue.
