### PR TITLE
use grunt bin provided by the required package

### DIFF
--- a/src/cli/index.coffee
+++ b/src/cli/index.coffee
@@ -17,7 +17,7 @@ endOfInit = (name, showGrunt) ->
 	command = 'cd '+ name + ' && npm install'
 	if showGrunt
 		info += ' and grunt.'
-		command += ' && grunt'
+		command += ' && $(npm bin)/grunt'
 	else
 		info += '.'
 	console.log info.green + ' Please wait, this might take up to a few minutes.'.yellow


### PR DESCRIPTION
Untested, but if you invoke grunt without $(npm bin)/ you will use whatever version of grunt was installed by the user, regardless of what is in package.json.  You want to invoke the version of grunt you specify, not what the user has installed with -g.