### PR TITLE
Added OAuth 2.0 support to Fitbit provider

### DIFF
--- a/providers/fitbit/conf.json
+++ b/providers/fitbit/conf.json
@@ -1,7 +1,7 @@
 {
 	"name": "FitBit",
     "desc": "Fitbit is a website that offers tools for users to track their personal data, such as weight, activity, total sleep, etc. Fitbit also offers an API for developers to use to create tools and application that access Fitbit services and data. Users can then authenticate an external website/application to use their Fitbit data, and use the external application to push data to Fitbit. The API is still being developed.",
-	"url": "https://api.fitbit.com/oauth",
+	"url": "https://api.fitbit.com",
 	"mobile": {
 		"params": {
 			"display": "touch"
@@ -10,7 +10,16 @@
 	"oauth1": {
 		"request_token": "/request_token",
 		"authorize": "https://www.fitbit.com/oauth/authorize",
-		"access_token": "/access_token"
+		"access_token": "/oauth/access_token"
+	},
+	"oauth2": {
+		"authorize": "https://www.fitbit.com/oauth2/authorize",
+		"access_token": {
+			"url": "/oauth2/token",
+			"headers": {
+				"Authorization": "Basic !BASE64{client_id}:{client_secret}!BASE64"
+			}
+		}
 	},
 	"href": {
 		"keys": "https://dev.fitbit.com/apps/new",


### PR DESCRIPTION
OAuth 1.0 provides limited access to Fitbit data, additionally Fitbit will be removing OAuth 1.0 support on 12th April 2016. This pull request adds OAuth 2.0 support to the Fitbit provider.