### PR TITLE
When no plugins installed don't run any grunt tasks.

### DIFF
--- a/src/scaffolding/templates/basis_structure/Gruntfile.js
+++ b/src/scaffolding/templates/basis_structure/Gruntfile.js
@@ -42,6 +42,10 @@ module.exports = function(grunt) {
         }
     }
 
+    if (added_plg.length === 0){
+        gruntConf.taskDefault = [];
+    }
+
     grunt.initConfig(gruntConf);
 
     // These plugins provide necessary tasks.


### PR DESCRIPTION
If you don't install any plugins during the `init` process the grunt inside the instance folder fails because of warnings from the `coffee` and `subgrunt` tasks not having any targets.

Example of error:

```
>> No "coffee" targets found.
Warning: Task "coffee" failed. Use --force to continue.

Aborted due to warnings.
```

So I would suggest clearing the array with the default tasks, since there is no need to run them and using always `--force` feels ominous.

Also, as a side question I am wondering what is the purpose of the `coffee` task inside the `instance_folder/Gruntfile.js` since each plugin will take care of its own `.coffee` files and there are no `.coffee` files in the instance directory.

Thanks,
Chris
