### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 services:
  - redis
 before_install:
- - "npm install -g grunt-cli coffee-script jasmine-node"
+ - "npm install -g grunt-cli coffee-script jasmine-node@1.14.5"
 install:
  - "npm install"
 script:


### PR DESCRIPTION
Closes #221 
Set specific(4 years old and dependent on CoffeeScript 2) jasmine-node package version.
The latest version of jasmine-node package is dependent on CoffeeScript 2,
which syntax is quite different. This causes syntax errors during 'npm test' command execution.